### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the action will run.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Ryu236/portfolio/security/code-scanning/1](https://github.com/Ryu236/portfolio/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository, setting up dependencies, building, and running tests, it only requires `contents: read` permissions. This ensures that the workflow has the minimal permissions necessary to perform its tasks.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This approach is simpler and avoids redundancy, as there is only one job in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
